### PR TITLE
Add sha input to install a specific commit SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,44 @@ jobs:
           echo "Version: ${{ steps.setup.outputs.asc-version }}"
           asc version
 
+  setup-main:
+    name: "main (ubuntu-latest)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: setup
+        uses: ./
+        with:
+          version: main
+
+      - name: Verify main install
+        shell: bash
+        run: |
+          echo "Path: ${{ steps.setup.outputs.asc-path }}"
+          echo "Version: ${{ steps.setup.outputs.asc-version }}"
+          asc version
+
+  setup-invalid-sha:
+    name: "invalid sha (ubuntu-latest)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: setup
+        continue-on-error: true
+        uses: ./
+        with:
+          sha: abc1234def5678
+
+      - name: Verify invalid sha fails
+        shell: bash
+        run: |
+          if [ "${{ steps.setup.outcome }}" != "failure" ]; then
+            echo "::error::Invalid sha should fail validation"
+            exit 1
+          fi
+
   setup-no-cache:
     name: "no-cache (ubuntu-latest)"
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,6 @@ jobs:
           echo "Path: ${{ steps.setup.outputs.asc-path }}"
           echo "Version: ${{ steps.setup.outputs.asc-version }}"
           asc version
-          asc --help
 
   setup-no-cache:
     name: "no-cache (ubuntu-latest)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,25 @@ jobs:
           echo "Installed: ${INSTALLED}"
           asc --help
 
+  setup-sha:
+    name: "sha (ubuntu-latest)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: setup
+        uses: ./
+        with:
+          sha: 23619c9fd56e150104079b8a7fd1b17b396e99ce
+
+      - name: Verify sha install
+        shell: bash
+        run: |
+          echo "Path: ${{ steps.setup.outputs.asc-path }}"
+          echo "Version: ${{ steps.setup.outputs.asc-version }}"
+          asc version
+          asc --help
+
   setup-no-cache:
     name: "no-cache (ubuntu-latest)"
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ Install from `main` (builds from source via `go install`, slower but useful for 
     version: main
 ```
 
-Install a specific commit SHA (builds from source via `go install`):
+Install a specific full commit SHA (builds from source via `go install`):
 
 ```yaml
 - uses: rudrankriyam/setup-asc@v1
   with:
-    sha: abc1234def5678...
+    sha: 23619c9fd56e150104079b8a7fd1b17b396e99ce
 ```
 
 ## Inputs
@@ -43,7 +43,7 @@ Install a specific commit SHA (builds from source via `go install`):
 | Input | Default | Description |
 |-------|---------|-------------|
 | `version` | `latest` | `latest`, `0.28.12`, `v0.28.12`, or `main` |
-| `sha` | | Exact commit SHA to install via `go install` (overrides `version`) |
+| `sha` | | Full 40-character commit SHA to install via `go install` (overrides `version`) |
 | `cache` | `true` | Cache the downloaded release asset |
 | `token` | `${{ github.token }}` | GitHub token (avoids API rate limits) |
 | `install-dir` | `$RUNNER_TEMP/asc/bin` | Directory to install `asc` into |

--- a/README.md
+++ b/README.md
@@ -30,11 +30,20 @@ Install from `main` (builds from source via `go install`, slower but useful for 
     version: main
 ```
 
+Install a specific commit SHA (builds from source via `go install`):
+
+```yaml
+- uses: rudrankriyam/setup-asc@v1
+  with:
+    sha: abc1234def5678...
+```
+
 ## Inputs
 
 | Input | Default | Description |
 |-------|---------|-------------|
 | `version` | `latest` | `latest`, `0.28.12`, `v0.28.12`, or `main` |
+| `sha` | | Exact commit SHA to install via `go install` (overrides `version`) |
 | `cache` | `true` | Cache the downloaded release asset |
 | `token` | `${{ github.token }}` | GitHub token (avoids API rate limits) |
 | `install-dir` | `$RUNNER_TEMP/asc/bin` | Directory to install `asc` into |

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,9 @@ inputs:
     description: "Version to install: latest, 0.28.12, v0.28.12, or main"
     required: false
     default: latest
+  sha:
+    description: "Exact commit SHA to install via go install (overrides version)"
+    required: false
   cache:
     description: "Cache the downloaded release asset (true/false)"
     required: false
@@ -41,6 +44,7 @@ runs:
 
         REPO="rudrankriyam/App-Store-Connect-CLI"
 
+        INPUT_SHA="${{ inputs.sha }}"
         INPUT_VERSION="${{ inputs.version }}"
         # Strip leading 'v' so both v0.28.12 and 0.28.12 work
         INPUT_VERSION="${INPUT_VERSION#v}"
@@ -67,7 +71,10 @@ runs:
         VERSION="${INPUT_VERSION}"
         MODE="release"
 
-        if [ -z "${INPUT_VERSION}" ] || [ "${INPUT_VERSION}" = "latest" ]; then
+        if [ -n "${INPUT_SHA}" ]; then
+          MODE="go"
+          VERSION="${INPUT_SHA}"
+        elif [ -z "${INPUT_VERSION}" ] || [ "${INPUT_VERSION}" = "latest" ]; then
           echo "::group::Resolving latest version"
           LATEST_URL="$(curl -fsSL -o /dev/null -w "%{url_effective}" \
             -H "Authorization: token ${{ inputs.token }}" \
@@ -200,7 +207,7 @@ runs:
         mkdir -p "${INSTALL_DIR}"
 
         if [ "${{ steps.resolve.outputs.mode }}" = "go" ]; then
-          GOBIN="${INSTALL_DIR}" go install github.com/rudrankriyam/App-Store-Connect-CLI@main
+          GOBIN="${INSTALL_DIR}" go install github.com/rudrankriyam/App-Store-Connect-CLI@${{ steps.resolve.outputs.version }}
           BIN_PATH="${INSTALL_DIR}/asc"
         else
           DIR="${{ steps.download.outputs.download-dir }}"

--- a/action.yml
+++ b/action.yml
@@ -208,7 +208,16 @@ runs:
 
         if [ "${{ steps.resolve.outputs.mode }}" = "go" ]; then
           GOBIN="${INSTALL_DIR}" go install github.com/rudrankriyam/App-Store-Connect-CLI@${{ steps.resolve.outputs.version }}
-          BIN_PATH="${INSTALL_DIR}/asc"
+          # go install names the binary after the module's last path element
+          # (App-Store-Connect-CLI), not 'asc'. Normalize it.
+          BIN_NAME="asc"
+          if [ "${{ steps.resolve.outputs.os }}" = "windows" ]; then BIN_NAME="asc.exe"; fi
+          if [ ! -f "${INSTALL_DIR}/${BIN_NAME}" ]; then
+            INSTALLED="$(ls "${INSTALL_DIR}" | head -1)"
+            mv "${INSTALL_DIR}/${INSTALLED}" "${INSTALL_DIR}/${BIN_NAME}"
+          fi
+          chmod +x "${INSTALL_DIR}/${BIN_NAME}" || true
+          BIN_PATH="${INSTALL_DIR}/${BIN_NAME}"
         else
           DIR="${{ steps.download.outputs.download-dir }}"
           cp "${DIR}/${{ steps.resolve.outputs.asset }}" "${INSTALL_DIR}/${{ steps.resolve.outputs.bin-name }}"

--- a/action.yml
+++ b/action.yml
@@ -39,13 +39,15 @@ runs:
     - name: Resolve version and platform
       id: resolve
       shell: bash
+      env:
+        INPUT_SHA: ${{ inputs.sha }}
+        INPUT_VERSION: ${{ inputs.version }}
+        INPUT_TOKEN: ${{ inputs.token }}
       run: |
         set -euo pipefail
 
         REPO="rudrankriyam/App-Store-Connect-CLI"
 
-        INPUT_SHA="${{ inputs.sha }}"
-        INPUT_VERSION="${{ inputs.version }}"
         # Strip leading 'v' so both v0.28.12 and 0.28.12 work
         INPUT_VERSION="${INPUT_VERSION#v}"
 
@@ -72,12 +74,16 @@ runs:
         MODE="release"
 
         if [ -n "${INPUT_SHA}" ]; then
+          if ! [[ "${INPUT_SHA}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "::error::sha must be a full 40-character commit SHA"
+            exit 1
+          fi
           MODE="go"
           VERSION="${INPUT_SHA}"
         elif [ -z "${INPUT_VERSION}" ] || [ "${INPUT_VERSION}" = "latest" ]; then
           echo "::group::Resolving latest version"
           LATEST_URL="$(curl -fsSL -o /dev/null -w "%{url_effective}" \
-            -H "Authorization: token ${{ inputs.token }}" \
+            -H "Authorization: token ${INPUT_TOKEN}" \
             "https://github.com/${REPO}/releases/latest")"
           VERSION="${LATEST_URL##*/}"
           if [ -z "${VERSION}" ] || [ "${VERSION}" = "latest" ]; then
@@ -125,17 +131,24 @@ runs:
       id: download
       if: ${{ steps.resolve.outputs.mode == 'release' }}
       shell: bash
+      env:
+        RESOLVED_VERSION: ${{ steps.resolve.outputs.version }}
+        RESOLVED_OS: ${{ steps.resolve.outputs.os }}
+        RESOLVED_ARCH: ${{ steps.resolve.outputs.arch }}
+        RESOLVED_ASSET: ${{ steps.resolve.outputs.asset }}
+        RESOLVED_BIN_URL: ${{ steps.resolve.outputs.bin-url }}
+        RESOLVED_CHECKSUMS_URL: ${{ steps.resolve.outputs.checksums-url }}
       run: |
         set -euo pipefail
         echo "::group::Download"
 
         CACHE_ROOT="${RUNNER_TEMP}/setup-asc-cache"
-        DOWNLOAD_DIR="${CACHE_ROOT}/${{ steps.resolve.outputs.version }}/${{ steps.resolve.outputs.os }}-${{ steps.resolve.outputs.arch }}"
+        DOWNLOAD_DIR="${CACHE_ROOT}/${RESOLVED_VERSION}/${RESOLVED_OS}-${RESOLVED_ARCH}"
         mkdir -p "${DOWNLOAD_DIR}"
 
-        ASSET="${{ steps.resolve.outputs.asset }}"
-        BIN_URL="${{ steps.resolve.outputs.bin-url }}"
-        CHECKSUMS_URL="${{ steps.resolve.outputs.checksums-url }}"
+        ASSET="${RESOLVED_ASSET}"
+        BIN_URL="${RESOLVED_BIN_URL}"
+        CHECKSUMS_URL="${RESOLVED_CHECKSUMS_URL}"
 
         if [ -f "${DOWNLOAD_DIR}/${ASSET}" ]; then
           echo "Using cached ${ASSET}"
@@ -154,12 +167,15 @@ runs:
     - name: Verify SHA-256 checksum
       if: ${{ steps.resolve.outputs.mode == 'release' }}
       shell: bash
+      env:
+        DOWNLOAD_DIR: ${{ steps.download.outputs.download-dir }}
+        RESOLVED_ASSET: ${{ steps.resolve.outputs.asset }}
       run: |
         set -euo pipefail
         echo "::group::Verify checksum"
 
-        DIR="${{ steps.download.outputs.download-dir }}"
-        ASSET="${{ steps.resolve.outputs.asset }}"
+        DIR="${DOWNLOAD_DIR}"
+        ASSET="${RESOLVED_ASSET}"
         FILE="${DIR}/${ASSET}"
         CHECKSUMS="${DIR}/checksums.txt"
 
@@ -196,38 +212,53 @@ runs:
     - name: Install asc
       id: install
       shell: bash
+      env:
+        INSTALL_DIR_INPUT: ${{ inputs.install-dir }}
+        RESOLVED_MODE: ${{ steps.resolve.outputs.mode }}
+        RESOLVED_VERSION: ${{ steps.resolve.outputs.version }}
+        RESOLVED_OS: ${{ steps.resolve.outputs.os }}
+        DOWNLOAD_DIR: ${{ steps.download.outputs.download-dir }}
+        RESOLVED_ASSET: ${{ steps.resolve.outputs.asset }}
+        RESOLVED_BIN_NAME: ${{ steps.resolve.outputs.bin-name }}
       run: |
         set -euo pipefail
         echo "::group::Install"
 
-        INSTALL_DIR="${{ inputs.install-dir }}"
+        INSTALL_DIR="${INSTALL_DIR_INPUT}"
         if [ -z "${INSTALL_DIR}" ]; then
           INSTALL_DIR="${RUNNER_TEMP}/asc/bin"
         fi
         mkdir -p "${INSTALL_DIR}"
 
-        if [ "${{ steps.resolve.outputs.mode }}" = "go" ]; then
-          GOBIN="${INSTALL_DIR}" go install github.com/rudrankriyam/App-Store-Connect-CLI@${{ steps.resolve.outputs.version }}
+        if [ "${RESOLVED_MODE}" = "go" ]; then
+          GOBIN="${INSTALL_DIR}" go install github.com/rudrankriyam/App-Store-Connect-CLI@${RESOLVED_VERSION}
           # go install names the binary after the module's last path element
           # (App-Store-Connect-CLI), not 'asc'. Normalize it.
           BIN_NAME="asc"
-          if [ "${{ steps.resolve.outputs.os }}" = "windows" ]; then BIN_NAME="asc.exe"; fi
+          GO_BIN_NAME="App-Store-Connect-CLI"
+          if [ "${RESOLVED_OS}" = "windows" ]; then
+            BIN_NAME="asc.exe"
+            GO_BIN_NAME="App-Store-Connect-CLI.exe"
+          fi
           if [ ! -f "${INSTALL_DIR}/${BIN_NAME}" ]; then
-            INSTALLED="$(ls "${INSTALL_DIR}" | head -1)"
-            mv "${INSTALL_DIR}/${INSTALLED}" "${INSTALL_DIR}/${BIN_NAME}"
+            if [ ! -f "${INSTALL_DIR}/${GO_BIN_NAME}" ]; then
+              echo "::error::Expected go install output at ${INSTALL_DIR}/${GO_BIN_NAME}"
+              exit 1
+            fi
+            mv "${INSTALL_DIR}/${GO_BIN_NAME}" "${INSTALL_DIR}/${BIN_NAME}"
           fi
           chmod +x "${INSTALL_DIR}/${BIN_NAME}" || true
           BIN_PATH="${INSTALL_DIR}/${BIN_NAME}"
         else
-          DIR="${{ steps.download.outputs.download-dir }}"
-          cp "${DIR}/${{ steps.resolve.outputs.asset }}" "${INSTALL_DIR}/${{ steps.resolve.outputs.bin-name }}"
-          chmod +x "${INSTALL_DIR}/${{ steps.resolve.outputs.bin-name }}" || true
-          BIN_PATH="${INSTALL_DIR}/${{ steps.resolve.outputs.bin-name }}"
+          DIR="${DOWNLOAD_DIR}"
+          cp "${DIR}/${RESOLVED_ASSET}" "${INSTALL_DIR}/${RESOLVED_BIN_NAME}"
+          chmod +x "${INSTALL_DIR}/${RESOLVED_BIN_NAME}" || true
+          BIN_PATH="${INSTALL_DIR}/${RESOLVED_BIN_NAME}"
         fi
 
         echo "${INSTALL_DIR}" >> "${GITHUB_PATH}"
         echo "asc-path=${BIN_PATH}" >> "${GITHUB_OUTPUT}"
-        echo "Installed asc ${{ steps.resolve.outputs.version }} at ${BIN_PATH}"
+        echo "Installed asc ${RESOLVED_VERSION} at ${BIN_PATH}"
         echo "::endgroup::"
 
 branding:


### PR DESCRIPTION
## Summary

Adds a new optional `sha` input that allows pinning to an exact commit SHA via `go install`. This is pretty critical for security minded environments where it is best practice to pin dependencies to a known sha rather than rely on (mutable) tags.

Closes #1.

## Changes

- `action.yml` — New `sha` input declared; resolve step checks `sha` before `version` and sets `mode=go` with the SHA as the install ref; `go install` now uses the dynamically resolved version instead of the hardcoded `@main`
- `README.md` — Usage example and inputs table updated to document `sha`

## Testing

- Existing `version: latest`, `version: <tag>`, and `version: main` paths are unchanged
- `sha` short-circuits version resolution and delegates to the same `go install` + `setup-go` path already exercised by `version: main`

## Notes

- `sha` takes precedence over `version` when both are set
- Caching is skipped (consistent with `version: main` behaviour)
- `asc-version` output will contain the SHA that was installed